### PR TITLE
Fix `--range` example in 'README.md' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo install codesort
 #### Sort a range in a file
 
 ```
-codesort --range 84:56 src/my/file.rs
+codesort --range 6:26 src/my/file.rs
 ```
 
 #### Sort around a line


### PR DESCRIPTION
This makes the provided range a valid one, as well as one that matches the discussion from "Sort around a line" example, illustrating the two possible approaches using the same lines.